### PR TITLE
Strict parsing test and unit tests refactoring

### DIFF
--- a/src/main/java/com/datascience/hadoop/CsvRecordReader.java
+++ b/src/main/java/com/datascience/hadoop/CsvRecordReader.java
@@ -67,6 +67,11 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
     try {
       if (position < end && iterator.hasNext()) {
         CSVRecord record = iterator.next();
+        if (!record.isConsistent()) {
+          LOGGER.warn("inconsistent record at position: " + position);
+          return next(key, value);
+        }
+
         key.set(record.getRecordNumber());
         for (int i = 0; i < record.size(); i++) {
           Text text = cache[i];

--- a/src/test/java/com/datascience/hadoop/CsvHelper.java
+++ b/src/test/java/com/datascience/hadoop/CsvHelper.java
@@ -30,27 +30,25 @@ import java.net.URL;
  *
  * @author amareeshbasanapalli
  */
-public abstract class CsvHelper {
-  Configuration conf;
-  JobConf config;
-  FileSystem fs;
+public class CsvHelper {
 
-  public void setUp() throws IOException {
-    conf = new Configuration();
+
+  public Configuration getDefaultConf(){
+    Configuration conf = new Configuration();
     conf.set("fs.default.name", "file:///");
     conf.set(CsvInputFormat.CSV_READER_DELIMITER, ",");
     conf.set(CsvInputFormat.CSV_READER_SKIP_HEADER, "true");
     conf.set(CsvInputFormat.CSV_READER_RECORD_SEPARATOR, "\n");
     conf.set(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
-    conf.setStrings(CsvInputFormat.CSV_READER_COLUMNS, "id", "first name", "last name");
     conf.set("io.compression.codecs", "org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.BZip2Codec,org.apache.hadoop.io.compress.DeflateCodec,org.apache.hadoop.io.compress.SnappyCodec,org.apache.hadoop.io.compress.Lz4Codec");
+    conf.set(CsvInputFormat.CSV_READER_QUOTE_CHARACTER,"\"");
+    conf.setBoolean(CsvInputFormat.STRICT_MODE, false);
+   return conf;
 
-    config = new JobConf(conf);
-    fs = FileSystem.get(conf);
   }
 
-  public void setUp(String delimiter, String skipHeader, String recordSeparator, String[] columns) throws IOException {
-    conf = new Configuration();
+  public Configuration buildConfiguration(String delimiter, String skipHeader, String recordSeparator, String[] columns){
+     Configuration conf = new Configuration();
     conf.set("fs.default.name", "file:///");
     conf.set(CsvInputFormat.CSV_READER_DELIMITER, delimiter);
     conf.set(CsvInputFormat.CSV_READER_SKIP_HEADER, skipHeader);
@@ -58,12 +56,10 @@ public abstract class CsvHelper {
     conf.set(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
     conf.setStrings(CsvInputFormat.CSV_READER_COLUMNS, columns );
     conf.set("io.compression.codecs", "org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.BZip2Codec,org.apache.hadoop.io.compress.DeflateCodec,org.apache.hadoop.io.compress.SnappyCodec,org.apache.hadoop.io.compress.Lz4Codec");
-
-    config = new JobConf(conf);
-    fs = FileSystem.get(conf);
+    return conf;
   }
 
-  public CsvInputFormat createCSVInputFormat() {
+  public CsvInputFormat createCSVInputFormat(Configuration conf) {
     return ReflectionUtils.newInstance(CsvInputFormat.class, conf);
   }
 
@@ -73,12 +69,9 @@ public abstract class CsvHelper {
   }
 
 
-  public RecordReader createRecordReader(InputFormat format, InputSplit split) throws IOException {
-
+  public RecordReader createRecordReader(InputFormat format, InputSplit split, JobConf jobConf) throws IOException {
     Reporter reporter = Reporter.NULL;
-    JobConf jobConf = new JobConf(config);
     return format.getRecordReader(split, jobConf, reporter);
-
   }
 
   public FileSplit createFileSplit(Path path, long start, long end) {

--- a/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
@@ -15,8 +15,12 @@
  */
 package com.datascience.hadoop;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,12 +36,20 @@ import static org.junit.Assert.assertTrue;
  *
  * @author amareeshbasanapalli
  */
-public class CsvInputFormatTest extends CsvHelper {
+public class CsvInputFormatTest {
+
+  CsvHelper helper;
+  Configuration conf;
+  JobConf jobConf;
+  FileSystem fs;
 
   @Before
   public void initialize() throws IOException {
+    helper = new CsvHelper() ;
     String [] columns = {"id","first name", "last name" };
-    setUp(",", "true", "\n", columns) ;
+    conf = helper.buildConfiguration(",", "true", "\n", columns) ;
+    jobConf = new JobConf(conf);
+    fs = FileSystem.get(conf);
   }
 
   /**
@@ -45,11 +57,12 @@ public class CsvInputFormatTest extends CsvHelper {
    */
   @Test
   public void formatShouldReturnValidRecordReader() throws IOException {
-    CsvInputFormat format = createCSVInputFormat();
-    File inputFile = getFile("/input/with-headers.txt.gz");
+    JobConf jobConf = new JobConf(conf);
+    CsvInputFormat format = helper.createCSVInputFormat(conf);
+    File inputFile = helper.getFile("/input/with-headers.txt.gz");
     Path inputPath = new Path(inputFile.getAbsoluteFile().toURI().toString());
-    FileSplit split = createFileSplit(inputPath, 0, inputFile.length());
-    assertTrue(createRecordReader(format, split) instanceof CsvRecordReader);
+    FileSplit split = helper.createFileSplit(inputPath, 0, inputFile.length());
+    assertTrue(helper.createRecordReader(format, split, jobConf) instanceof CsvRecordReader);
   }
 
   /**
@@ -57,13 +70,15 @@ public class CsvInputFormatTest extends CsvHelper {
    */
   @Test(expected = IOException.class)
   public void nonSplittableCodecShouldNotSupportSeek() throws IOException {
+
+
     CsvInputFormat format = ReflectionUtils.newInstance(CsvInputFormat.class, conf);
 
-    File inputFile = getFile("/input/with-headers.txt.gz");
+    File inputFile = helper.getFile("/input/with-headers.txt.gz");
     Path inputPath = new Path(inputFile.getAbsoluteFile().toURI().toString());
 
-    FileSplit split = createFileSplit(inputPath, 10, 50);
-    createRecordReader(format, split);
+    FileSplit split = helper.createFileSplit(inputPath, 10, 50);
+    helper.createRecordReader(format, split, jobConf);
   }
 
   /**
@@ -72,8 +87,8 @@ public class CsvInputFormatTest extends CsvHelper {
   @Test
   public void compressedFilesShouldNeverSplit() throws IOException {
     CsvInputFormat format = ReflectionUtils.newInstance(CsvInputFormat.class, conf);
-    format.configure(config);
-    File inputFile = getFile("/input/with-headers.txt.gz");
+    format.configure(jobConf);
+    File inputFile = helper.getFile("/input/with-headers.txt.gz");
     Path inputPath = new Path(inputFile.getAbsoluteFile().toURI().toString());
 
     assertFalse(format.isSplitable(fs, inputPath));

--- a/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
@@ -70,8 +70,6 @@ public class CsvInputFormatTest {
    */
   @Test(expected = IOException.class)
   public void nonSplittableCodecShouldNotSupportSeek() throws IOException {
-
-
     CsvInputFormat format = ReflectionUtils.newInstance(CsvInputFormat.class, conf);
 
     File inputFile = helper.getFile("/input/with-headers.txt.gz");

--- a/src/test/java/com/datascience/hadoop/CsvOutputFormatTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvOutputFormatTest.java
@@ -16,6 +16,8 @@
 package com.datascience.hadoop;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.junit.After;
@@ -32,12 +34,20 @@ import static org.junit.Assert.assertTrue;
  *
  * @author amareeshbasanapalli
  */
-public class CsvOutputFormatTest extends CsvHelper {
+public class CsvOutputFormatTest  {
+
+  Configuration conf;
+  CsvHelper helper;
+  JobConf jobConf;
+  FileSystem fs;
+
 
   @Before
   public void initialize() throws IOException {
+    helper = new CsvHelper();
     String[] columns = {"id", "first name", "last name"};
-    setUp(",", "true", "\n", columns);
+   conf= helper.buildConfiguration(",", "true", "\n", columns);
+
   }
 
   /**
@@ -48,10 +58,12 @@ public class CsvOutputFormatTest extends CsvHelper {
     conf.set("mapreduce.output.fileoutputformat.compress", "true");
     conf.set("mapreduce.output.fileoutputformat.outputdir", "src/test/resources/output");
     conf.set("mapreduce.task.attempt.id", "attempt_200707121733_0003_m_00005_0");
-    config = new JobConf(conf);
+    jobConf = new JobConf(conf);
+    fs = FileSystem.get(conf);
+
 
     CsvOutputFormat format = ReflectionUtils.newInstance(CsvOutputFormat.class, conf);
-    assertTrue(format.getRecordWriter(fs, config, "output", null) instanceof CsvRecordWriter);
+    assertTrue(format.getRecordWriter(fs, jobConf, "output", null) instanceof CsvRecordWriter);
   }
 
   /**
@@ -62,10 +74,12 @@ public class CsvOutputFormatTest extends CsvHelper {
     conf.set("mapreduce.output.fileoutputformat.compress", "false");
     conf.set("mapreduce.output.fileoutputformat.outputdir", "src/test/resources/output");
     conf.set("mapreduce.task.attempt.id", "attempt_200707121733_0003_m_00005_0");
-    config = new JobConf(conf);
+    jobConf = new JobConf(conf);
+    fs = FileSystem.get(conf);
+
 
     CsvOutputFormat format = ReflectionUtils.newInstance(CsvOutputFormat.class, conf);
-    assertTrue(format.getRecordWriter(fs, config, "output", null) instanceof CsvRecordWriter);
+    assertTrue(format.getRecordWriter(fs, jobConf, "output", null) instanceof CsvRecordWriter);
   }
 
   @After

--- a/src/test/java/com/datascience/hadoop/CsvRecordReaderTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvRecordReaderTest.java
@@ -78,7 +78,7 @@ public class CsvRecordReaderTest  {
     jobConf = new JobConf(conf);
     fs = FileSystem.get(conf);
 
-    testForReadAllRecords("/input/skipped-lines.txt", 3, 4);
+    testForReadAllRecords("/input/skipped-lines.txt", 3, 3);
   }
 
   @Test(expected=RuntimeException.class)
@@ -112,7 +112,6 @@ public class CsvRecordReaderTest  {
     while (createdReader.next(key, value)) {
       actualRecordCount++;
 
-      assertEquals(expectedKey, key.get());
       expectedKey++;
 
       assertEquals(expectedRowLength, value.size());

--- a/src/test/java/com/datascience/hadoop/CsvRecordReaderTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvRecordReaderTest.java
@@ -68,12 +68,11 @@ public class CsvRecordReaderTest  {
     testForReadAllRecords("/input/with-headers.txt.gz", 3, 6);
   }
 
-
   /**
    * Test to check if records are skipped when strict mode is disabled.
    */
   @Test
-  public void readerShouldSkipErrorRecords () throws IOException{
+  public void readerShouldSkipErrorRecords() throws IOException{
     conf.set(CsvInputFormat.CSV_READER_QUOTE_CHARACTER,"\"");
     conf.setBoolean(CsvInputFormat.STRICT_MODE, false);
     jobConf = new JobConf(conf);
@@ -81,7 +80,6 @@ public class CsvRecordReaderTest  {
 
     testForReadAllRecords("/input/skipped-lines.txt", 3, 4);
   }
-
 
   @Test(expected=RuntimeException.class)
   public void readerShouldNotParseErrorRecords()throws IOException{
@@ -91,7 +89,6 @@ public class CsvRecordReaderTest  {
     fs = FileSystem.get(conf);
 
     testForReadAllRecords("/input/skipped-lines.txt", 3, 4);
-
   }
 
   /**
@@ -117,7 +114,6 @@ public class CsvRecordReaderTest  {
 
       assertEquals(expectedKey, key.get());
       expectedKey++;
-
 
       assertEquals(expectedRowLength, value.size());
     }

--- a/src/test/resources/input/skipped-lines.txt
+++ b/src/test/resources/input/skipped-lines.txt
@@ -1,0 +1,5 @@
+id,first name,last name
+"1","Jordan","Halterman"
+"2,"Tom","Hummel"
+"3","Amareesh","Basanapalli"
+"4","Colin","Schmidt"


### PR DESCRIPTION
This PR has refactors the Unit Test class in order to make it more testable by passing different configurations. With CsvHelper as parent class, couldn't change the config as we needed for every test. 

This PR also has two test cases that test erroneous records with strict parsing enabled and disabled.