### PR TITLE
Handle parsing and formatting of null values

### DIFF
--- a/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
+++ b/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
@@ -352,7 +352,12 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
     TupleEntry entry = sourceCall.getIncomingEntry();
     ListWritable<Text> values = (ListWritable<Text>) context[1];
     for (int i = 0; i < values.size(); i++) {
-      entry.setString(i, values.get(i).toString());
+      Text value = values.get(i);
+      if (value == null) {
+        entry.setString(i, null);
+      } else {
+        entry.setString(i, value.toString());
+      }
     }
     return true;
   }
@@ -386,7 +391,11 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
     TupleEntry entry = sinkCall.getOutgoingEntry();
     Tuple tuple = entry.getTuple();
     for (Object value : tuple) {
-      record.add(new Text(value.toString()));
+      if (value == null) {
+        record.add(null);
+      } else {
+        record.add(new Text(value.toString()));
+      }
     }
 
     sinkCall.getOutput().collect(null, record);

--- a/src/main/java/com/datascience/hadoop/CsvRecordReader.java
+++ b/src/main/java/com/datascience/hadoop/CsvRecordReader.java
@@ -74,13 +74,18 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
 
         key.set(record.getRecordNumber());
         for (int i = 0; i < record.size(); i++) {
-          Text text = cache[i];
-          if (text == null) {
-            text = new Text();
-            cache[i] = text;
+          String item = record.get(i);
+          if (item == null) {
+            value.add(null);
+          } else {
+            Text text = cache[i];
+            if (text == null) {
+              text = new Text();
+              cache[i] = text;
+            }
+            text.set(item);
+            value.add(text);
           }
-          text.set(record.get(i));
-          value.add(text);
         }
         position = record.getCharacterPosition();
         return true;

--- a/src/test/java/com/datascience/cascading/CsvSchemeTest.java
+++ b/src/test/java/com/datascience/cascading/CsvSchemeTest.java
@@ -182,6 +182,31 @@ public class CsvSchemeTest {
   }
 
   /**
+   * Tests the CSV scheme reading and writing nulls.
+   */
+  @Test
+  public void testCsvNulls() throws Exception {
+    String sourcePath = "src/test/resources/input/with-nulls.txt";
+    String sinkPath = "src/test/resources/output/with-nulls";
+    String expectedPath = "src/test/resources/expected/with-nulls.txt";
+
+    CSVFormat sourceFormat = CSVFormat.newFormat(',')
+      .withQuote('"')
+      .withHeader("id", "first name", "last name")
+      .withSkipHeaderRecord()
+      .withEscape('\\')
+      .withRecordSeparator('\n')
+      .withNullString("\\N");
+
+    CSVFormat sinkFormat = CSVFormat.newFormat('\t')
+      .withEscape('\\')
+      .withRecordSeparator('\n')
+      .withNullString("null");
+
+    testScheme(sourcePath, sourceFormat, sinkPath, sinkFormat, expectedPath, true);
+  }
+
+  /**
    * Tests the CSV scheme sink without headers.
    */
   @Test

--- a/src/test/resources/expected/with-nulls.txt
+++ b/src/test/resources/expected/with-nulls.txt
@@ -1,0 +1,7 @@
+id	first name	last name
+1	Jordan	Halterman
+2	Tom	null
+3	Harrison	Cavallero
+4	null	Ahmed
+5	Tristan	Reid
+6	Mark	McKelvy

--- a/src/test/resources/input/with-nulls.txt
+++ b/src/test/resources/input/with-nulls.txt
@@ -1,0 +1,7 @@
+id,first name,last name
+1,Jordan,Halterman
+2,Tom,\N
+3,Harrison,Cavallero
+4,\N,Ahmed
+5,Tristan,Reid
+6,Mark,McKelvy


### PR DESCRIPTION
This PR ensures that `null` values can be properly read and written by the CSV scheme input/output formats and adds tests for handling null values in the CSV scheme.