### PR TITLE
Remove support for input splits

### DIFF
--- a/src/main/java/com/datascience/hadoop/CsvRecordReader.java
+++ b/src/main/java/com/datascience/hadoop/CsvRecordReader.java
@@ -47,17 +47,15 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
   private final Text[] cache = new Text[1024];
   private final CSVParser parser;
   private final Iterator<CSVRecord> iterator;
-  private final float start;
-  private final long end;
+  private final long length;
   private final boolean strict;
   private long position;
 
-  public CsvRecordReader(InputStream is, CSVFormat format, long start, long end, boolean strict) throws IOException {
-    this.start = start;
-    this.end = end;
+  public CsvRecordReader(InputStream is, CSVFormat format, long length, boolean strict) throws IOException {
+    this.length = length;
     this.strict = strict;
     Reader isr = new InputStreamReader(is);
-    parser = new CSVParser(isr, format, start, start);
+    parser = new CSVParser(isr, format);
     iterator = parser.iterator();
   }
 
@@ -65,7 +63,7 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
   public boolean next(LongWritable key, ListWritable<Text> value) throws IOException {
     value.clear();
     try {
-      if (position < end && iterator.hasNext()) {
+      if (iterator.hasNext()) {
         CSVRecord record = iterator.next();
         if (!record.isConsistent()) {
           LOGGER.warn("inconsistent record at position: " + position);
@@ -118,7 +116,7 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
 
   @Override
   public float getProgress() throws IOException {
-    return Math.min(1.0f, (float) position - start / (end - start));
+    return Math.min(1.0f, (float) position / length);
   }
 
   @Override

--- a/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
@@ -18,7 +18,6 @@ package com.datascience.hadoop;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.DFSClient;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -63,20 +62,6 @@ public class CsvInputFormatTest {
     Path inputPath = new Path(inputFile.getAbsoluteFile().toURI().toString());
     FileSplit split = helper.createFileSplit(inputPath, 0, inputFile.length());
     assertTrue(helper.createRecordReader(format, split, jobConf) instanceof CsvRecordReader);
-  }
-
-  /**
-   * Tests to see if compressed files support seek.
-   */
-  @Test(expected = IOException.class)
-  public void nonSplittableCodecShouldNotSupportSeek() throws IOException {
-    CsvInputFormat format = ReflectionUtils.newInstance(CsvInputFormat.class, conf);
-
-    File inputFile = helper.getFile("/input/with-headers.txt.gz");
-    Path inputPath = new Path(inputFile.getAbsoluteFile().toURI().toString());
-
-    FileSplit split = helper.createFileSplit(inputPath, 10, 50);
-    helper.createRecordReader(format, split, jobConf);
   }
 
   /**


### PR DESCRIPTION
This PR removes support for input splits for the time being.

There were some critical issues with the existing input split logic. Specifically, even while input splits were already not supported, the use of input split `length` in parsing resulted in parse lengths being miscalculated for compressed files. For instance, if a file was gzipped to `250` bytes, and thus the input split was `250` bytes, the parsing would stop at `250` bytes even though the decompressed file may be much larger. This is a critical issue as it results in the loss of data. Thus, I have removed all reliance on input splits for parsing.