### PR TITLE
Add support for specifying character set

### DIFF
--- a/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
+++ b/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
@@ -881,6 +881,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Configures the Hadoop configuration for the given CSV format.
    */
   private void configureReaderFormat(CSVFormat format, Configuration conf) {
+    conf.set(CsvOutputFormat.CHARSET, charset);
+
     // If the format header was explicitly provided by the user then forward it to the record reader. If skipHeaderRecord
     // is enabled then that indicates that field names were detected. We need to ensure that headers are defined in order
     // for the CSV reader to skip the header record.
@@ -922,6 +924,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Configures the Hadoop configuration for the given CSV format.
    */
   private void configureWriterFormat(CSVFormat format, Configuration conf) {
+    conf.set(CsvOutputFormat.CHARSET, charset);
+
     // Apache CSV doesn't really handle the skipHeaderRecord flag correctly when writing output. If the skip flag is set
     // and headers are configured, headers will always be written to the output. Since we always have headers and/or
     // fields configured, we need to use the skipHeaderRecord flag to determine whether headers should be written.

--- a/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
+++ b/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
@@ -82,6 +82,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * <p>
    * Strict mode is enabled when using this constructor.
    * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
+   * <p>
    * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
    * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
    * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
@@ -98,6 +100,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
    * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
    * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param charset The name of the character set with which to read and write CSV files.
    */
   public CsvScheme(String charset) {
     this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, Charset.forName(charset), true);
@@ -111,6 +115,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
    * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
    * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param charset The character set with which to read and write CSV files.
    */
   public CsvScheme(Charset charset) {
     this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, charset, true);
@@ -118,6 +124,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
 
   /**
    * Creates a new CSV scheme with the {@link org.apache.commons.csv.CSVFormat#DEFAULT} format.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
    * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
@@ -137,6 +145,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
    * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
    *
+   * @param charset The name of the character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -151,6 +160,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
    * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
    *
+   * @param charset The character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -162,6 +172,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Creates a new CSV scheme with the given {@link org.apache.commons.csv.CSVFormat}.
    * <p>
    * Strict mode is enabled when using this constructor.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * When used as a source, if {@link org.apache.commons.csv.CSVFormat#getHeader()} is specified, the provided header
    * column names will be used in the output {@link cascading.tuple.Fields}. If no headers are specified and
@@ -189,6 +201,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * {@code col1}, {@code col2}, {@code col3}, etc.
    *
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The name of the character set with which to read and write CSV files.
    */
   public CsvScheme(CSVFormat format, String charset) {
     this(Fields.ALL, Fields.ALL, format, charset, true);
@@ -206,6 +219,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * is {@code false} and no header record is provided, positional {@link cascading.tuple.Fields} will be generated, e.g.
    * {@code col1}, {@code col2}, {@code col3}, etc.
    *
+   * @param charset The character set with which to read and write CSV files.
    * @param format The format with which to parse (source) or format (sink) records.
    */
   public CsvScheme(CSVFormat format, Charset charset) {
@@ -214,6 +228,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
 
   /**
    * Creates a new CSV scheme with the given {@link org.apache.commons.csv.CSVFormat}.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * When used as a source, if {@link org.apache.commons.csv.CSVFormat#getHeader()} is specified, the provided header
    * column names will be used in the output {@link cascading.tuple.Fields}. If no headers are specified and
@@ -241,6 +257,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * {@code col1}, {@code col2}, {@code col3}, etc.
    *
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The name of the character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -259,6 +276,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * {@code col1}, {@code col2}, {@code col3}, etc.
    *
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -270,6 +288,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
    * <p>
    * Strict mode is enabled when using this constructor.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -291,6 +311,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * with the provided field names will be written to the output target.
    *
    * @param fields The source and sink fields.
+   * @param charset The name of the character set with which to read and write CSV files.
    */
   public CsvScheme(Fields fields, String charset) {
     this(fields, fields, CSVFormat.DEFAULT, Charset.forName(charset), true);
@@ -306,6 +327,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * with the provided field names will be written to the output target.
    *
    * @param fields The source and sink fields.
+   * @param charset The character set with which to read and write CSV files.
    */
   public CsvScheme(Fields fields, Charset charset) {
     this(fields, fields, CSVFormat.DEFAULT, charset, true);
@@ -313,6 +335,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
 
   /**
    * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -334,6 +358,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * with the provided field names will be written to the output target.
    *
    * @param fields The source and sink fields.
+   * @param charset The name of the character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -349,6 +374,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * with the provided field names will be written to the output target.
    *
    * @param fields The source and sink fields.
+   * @param charset The character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -361,6 +387,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * which to read and write CSV data.
    * <p>
    * Strict mode is enabled when using this constructor.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -393,6 +421,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param fields The source and sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The name of the character set with which to read and write CSV files.
    */
   public CsvScheme(Fields fields, CSVFormat format, String charset) {
     this(fields, fields, format, Charset.forName(charset), true);
@@ -414,6 +443,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param fields The source and sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The character set with which to read and write CSV files.
    */
   public CsvScheme(Fields fields, CSVFormat format, Charset charset) {
     this(fields, fields, format, charset, true);
@@ -422,6 +452,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
   /**
    * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
    * which to read and write CSV data.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -454,6 +486,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param fields The source and sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The name of the character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -475,6 +508,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param fields The source and sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -486,6 +520,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
    * <p>
    * Strict mode is enabled when using this constructor.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -509,6 +545,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
+   * @param charset The name of the character set with which to read and write CSV files.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields, String charset) {
     this(sourceFields, sinkFields, CSVFormat.DEFAULT, Charset.forName(charset), true);
@@ -525,6 +562,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
+   * @param charset The character set with which to read and write CSV files.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields, Charset charset) {
     this(sourceFields, sinkFields, CSVFormat.DEFAULT, charset, true);
@@ -532,6 +570,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
 
   /**
    * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -555,6 +595,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
+   * @param charset The name of the character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -571,6 +612,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
+   * @param charset The character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -583,6 +625,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * which to read and write CSV data.
    * <p>
    * Strict mode is enabled when using this constructor.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -617,6 +661,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The name of the character set with which to read and write CSV files.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format, String charset) {
     this(sourceFields, sinkFields, format, Charset.forName(charset), true);
@@ -639,6 +684,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The character set with which to read and write CSV files.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format, Charset charset) {
     this(sourceFields, sinkFields, format, charset, true);
@@ -647,6 +693,8 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
   /**
    * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
    * which to read and write CSV data.
+   * <p>
+   * The CSV input/output encoding set defaults to {@code UTF-8}
    * <p>
    * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
    * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
@@ -681,6 +729,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The name of the character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */
@@ -703,6 +752,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param sourceFields The source fields.
    * @param sinkFields The sink fields.
    * @param format The format with which to parse (source) or format (sink) records.
+   * @param charset The character set with which to read and write CSV files.
    * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
    *               parse errors will be caught and logged.
    */

--- a/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
+++ b/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * The CSV scheme provides support for parsing and formatting CSV files using
@@ -73,6 +75,7 @@ import java.io.IOException;
 public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Object[], Object[]> {
   private final CSVFormat format;
   private final boolean strict;
+  private final String charset;
 
   /**
    * Creates a new CSV scheme with {@link org.apache.commons.csv.CSVFormat#DEFAULT}.
@@ -84,7 +87,33 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
    */
   public CsvScheme() {
-    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, true);
+    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, StandardCharsets.UTF_8, true);
+  }
+
+  /**
+   * Creates a new CSV scheme with {@link org.apache.commons.csv.CSVFormat#DEFAULT}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
+   * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
+   * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
+   */
+  public CsvScheme(String charset) {
+    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, Charset.forName(charset), true);
+  }
+
+  /**
+   * Creates a new CSV scheme with {@link org.apache.commons.csv.CSVFormat#DEFAULT}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
+   * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
+   * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
+   */
+  public CsvScheme(Charset charset) {
+    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, charset, true);
   }
 
   /**
@@ -98,7 +127,35 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *               parse errors will be caught and logged.
    */
   public CsvScheme(boolean strict) {
-    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, strict);
+    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, StandardCharsets.UTF_8, strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the {@link org.apache.commons.csv.CSVFormat#DEFAULT} format.
+   * <p>
+   * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
+   * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
+   * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(String charset, boolean strict) {
+    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, Charset.forName(charset), strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the {@link org.apache.commons.csv.CSVFormat#DEFAULT} format.
+   * <p>
+   * Note that because the default {@link org.apache.commons.csv.CSVFormat} does not specify a header record or skip the
+   * header record, this constructor will result in {@link cascading.tuple.Fields} being dynamically generated for sources.
+   * Source fields will be generated with positional names, e.g. {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Charset charset, boolean strict) {
+    this(Fields.ALL, Fields.ALL, CSVFormat.DEFAULT, charset, strict);
   }
 
   /**
@@ -116,7 +173,43 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param format The format with which to parse (source) or format (sink) records.
    */
   public CsvScheme(CSVFormat format) {
-    this(Fields.ALL, Fields.ALL, format, true);
+    this(Fields.ALL, Fields.ALL, format, StandardCharsets.UTF_8, true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given {@link org.apache.commons.csv.CSVFormat}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * When used as a source, if {@link org.apache.commons.csv.CSVFormat#getHeader()} is specified, the provided header
+   * column names will be used in the output {@link cascading.tuple.Fields}. If no headers are specified and
+   * {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()} is {@code true}, the scheme will attempt to automatically
+   * detect the header record from the first record in the CSV input. If {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()}
+   * is {@code false} and no header record is provided, positional {@link cascading.tuple.Fields} will be generated, e.g.
+   * {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param format The format with which to parse (source) or format (sink) records.
+   */
+  public CsvScheme(CSVFormat format, String charset) {
+    this(Fields.ALL, Fields.ALL, format, charset, true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given {@link org.apache.commons.csv.CSVFormat}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * When used as a source, if {@link org.apache.commons.csv.CSVFormat#getHeader()} is specified, the provided header
+   * column names will be used in the output {@link cascading.tuple.Fields}. If no headers are specified and
+   * {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()} is {@code true}, the scheme will attempt to automatically
+   * detect the header record from the first record in the CSV input. If {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()}
+   * is {@code false} and no header record is provided, positional {@link cascading.tuple.Fields} will be generated, e.g.
+   * {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param format The format with which to parse (source) or format (sink) records.
+   */
+  public CsvScheme(CSVFormat format, Charset charset) {
+    this(Fields.ALL, Fields.ALL, format, charset, true);
   }
 
   /**
@@ -134,7 +227,43 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *               parse errors will be caught and logged.
    */
   public CsvScheme(CSVFormat format, boolean strict) {
-    this(Fields.ALL, Fields.ALL, format, strict);
+    this(Fields.ALL, Fields.ALL, format, StandardCharsets.UTF_8, strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given {@link org.apache.commons.csv.CSVFormat}.
+   * <p>
+   * When used as a source, if {@link org.apache.commons.csv.CSVFormat#getHeader()} is specified, the provided header
+   * column names will be used in the output {@link cascading.tuple.Fields}. If no headers are specified and
+   * {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()} is {@code true}, the scheme will attempt to automatically
+   * detect the header record from the first record in the CSV input. If {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()}
+   * is {@code false} and no header record is provided, positional {@link cascading.tuple.Fields} will be generated, e.g.
+   * {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param format The format with which to parse (source) or format (sink) records.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(CSVFormat format, String charset, boolean strict) {
+    this(Fields.ALL, Fields.ALL, format, Charset.forName(charset), strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given {@link org.apache.commons.csv.CSVFormat}.
+   * <p>
+   * When used as a source, if {@link org.apache.commons.csv.CSVFormat#getHeader()} is specified, the provided header
+   * column names will be used in the output {@link cascading.tuple.Fields}. If no headers are specified and
+   * {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()} is {@code true}, the scheme will attempt to automatically
+   * detect the header record from the first record in the CSV input. If {@link org.apache.commons.csv.CSVFormat#getSkipHeaderRecord()}
+   * is {@code false} and no header record is provided, positional {@link cascading.tuple.Fields} will be generated, e.g.
+   * {@code col1}, {@code col2}, {@code col3}, etc.
+   *
+   * @param format The format with which to parse (source) or format (sink) records.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(CSVFormat format, Charset charset, boolean strict) {
+    this(Fields.ALL, Fields.ALL, format, charset, strict);
   }
 
   /**
@@ -149,7 +278,37 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param fields The source and sink fields.
    */
   public CsvScheme(Fields fields) {
-    this(fields, fields, CSVFormat.DEFAULT, true);
+    this(fields, fields, CSVFormat.DEFAULT, StandardCharsets.UTF_8, true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param fields The source and sink fields.
+   */
+  public CsvScheme(Fields fields, String charset) {
+    this(fields, fields, CSVFormat.DEFAULT, Charset.forName(charset), true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param fields The source and sink fields.
+   */
+  public CsvScheme(Fields fields, Charset charset) {
+    this(fields, fields, CSVFormat.DEFAULT, charset, true);
   }
 
   /**
@@ -164,7 +323,37 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *               parse errors will be caught and logged.
    */
   public CsvScheme(Fields fields, boolean strict) {
-    this(fields, fields, CSVFormat.DEFAULT, strict);
+    this(fields, fields, CSVFormat.DEFAULT, StandardCharsets.UTF_8, strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param fields The source and sink fields.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields fields, String charset, boolean strict) {
+    this(fields, fields, CSVFormat.DEFAULT, Charset.forName(charset), strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param fields The source and sink fields.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields fields, Charset charset, boolean strict) {
+    this(fields, fields, CSVFormat.DEFAULT, charset, strict);
   }
 
   /**
@@ -185,7 +374,49 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param format The format with which to parse (source) or format (sink) records.
    */
   public CsvScheme(Fields fields, CSVFormat format) {
-    this(fields, fields, format, true);
+    this(fields, fields, format, StandardCharsets.UTF_8, true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record, the
+   * source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param fields The source and sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   */
+  public CsvScheme(Fields fields, CSVFormat format, String charset) {
+    this(fields, fields, format, Charset.forName(charset), true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record, the
+   * source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param fields The source and sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   */
+  public CsvScheme(Fields fields, CSVFormat format, Charset charset) {
+    this(fields, fields, format, charset, true);
   }
 
   /**
@@ -206,7 +437,49 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *               parse errors will be caught and logged.
    */
   public CsvScheme(Fields fields, CSVFormat format, boolean strict) {
-    this(fields, fields, format, strict);
+    this(fields, fields, format, StandardCharsets.UTF_8, strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record, the
+   * source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param fields The source and sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields fields, CSVFormat format, String charset, boolean strict) {
+    this(fields, fields, format, Charset.forName(charset), strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record, the
+   * source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param fields The source and sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields fields, CSVFormat format, Charset charset, boolean strict) {
+    this(fields, fields, format, charset, strict);
   }
 
   /**
@@ -222,7 +495,39 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param sinkFields The sink fields.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields) {
-    this(sourceFields, sinkFields, CSVFormat.DEFAULT, true);
+    this(sourceFields, sinkFields, CSVFormat.DEFAULT, StandardCharsets.UTF_8, true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, String charset) {
+    this(sourceFields, sinkFields, CSVFormat.DEFAULT, Charset.forName(charset), true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, Charset charset) {
+    this(sourceFields, sinkFields, CSVFormat.DEFAULT, charset, true);
   }
 
   /**
@@ -238,7 +543,39 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *               parse errors will be caught and logged.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields, boolean strict) {
-    this(sourceFields, sinkFields, CSVFormat.DEFAULT, strict);
+    this(sourceFields, sinkFields, CSVFormat.DEFAULT, StandardCharsets.UTF_8, strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, String charset, boolean strict) {
+    this(sourceFields, sinkFields, CSVFormat.DEFAULT, Charset.forName(charset), strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields}.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, Charset charset, boolean strict) {
+    this(sourceFields, sinkFields, CSVFormat.DEFAULT, charset, strict);
   }
 
   /**
@@ -260,7 +597,51 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    * @param format The format with which to parse (source) or format (sink) records.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format) {
-    this(sourceFields, sinkFields, format, true);
+    this(sourceFields, sinkFields, format, StandardCharsets.UTF_8, true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record,
+   * the source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format, String charset) {
+    this(sourceFields, sinkFields, format, Charset.forName(charset), true);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * Strict mode is enabled when using this constructor.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record,
+   * the source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format, Charset charset) {
+    this(sourceFields, sinkFields, format, charset, true);
   }
 
   /**
@@ -282,10 +663,55 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
    *               parse errors will be caught and logged.
    */
   public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format, boolean strict) {
+    this(sourceFields, sinkFields, format, StandardCharsets.UTF_8, strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record,
+   * the source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format, String charset, boolean strict) {
+    this(sourceFields, sinkFields, format, Charset.forName(charset), strict);
+  }
+
+  /**
+   * Creates a new CSV scheme with the given source and sink {@link cascading.tuple.Fields} and a custom format with
+   * which to read and write CSV data.
+   * <p>
+   * The provided {@link cascading.tuple.Fields} will be used both in sourcing and sinking. For sources, this constructor
+   * assumes that the provided number of fields match the number of columns in the source data. For sinks, only columns
+   * with the provided field names will be written to the output target.
+   * <p>
+   * Note that regardless of whether the {@link org.apache.commons.csv.CSVFormat} provides a header record,
+   * the source {@link cascading.tuple.Fields} take precedence, and the header record configured in the format
+   * will be essentially ignored.
+   *
+   * @param sourceFields The source fields.
+   * @param sinkFields The sink fields.
+   * @param format The format with which to parse (source) or format (sink) records.
+   * @param strict Indicates whether to parse records in strict parsing mode. When strict mode is disabled, single record
+   *               parse errors will be caught and logged.
+   */
+  public CsvScheme(Fields sourceFields, Fields sinkFields, CSVFormat format, Charset charset, boolean strict) {
     super();
     setSourceFields(sourceFields);
     setSinkFields(sinkFields);
     this.format = format;
+    this.charset = charset.name();
     this.strict = strict;
   }
 

--- a/src/main/java/com/datascience/hadoop/CsvRecordReader.java
+++ b/src/main/java/com/datascience/hadoop/CsvRecordReader.java
@@ -24,8 +24,6 @@ import org.apache.hadoop.mapred.RecordReader;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Iterator;
 
@@ -51,11 +49,10 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
   private final boolean strict;
   private long position;
 
-  public CsvRecordReader(InputStream is, CSVFormat format, long length, boolean strict) throws IOException {
+  public CsvRecordReader(Reader reader, CSVFormat format, long length, boolean strict) throws IOException {
     this.length = length;
     this.strict = strict;
-    Reader isr = new InputStreamReader(is);
-    parser = new CSVParser(isr, format);
+    parser = new CSVParser(reader, format);
     iterator = parser.iterator();
   }
 

--- a/src/main/java/com/datascience/hadoop/CsvRecordWriter.java
+++ b/src/main/java/com/datascience/hadoop/CsvRecordWriter.java
@@ -23,8 +23,7 @@ import org.apache.hadoop.mapred.RecordWriter;
 import org.apache.hadoop.mapred.Reporter;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
+import java.io.Writer;
 
 /**
  * CSV record writer.
@@ -39,8 +38,8 @@ import java.io.OutputStreamWriter;
 public class CsvRecordWriter implements RecordWriter<LongWritable, ListWritable<Text>> {
   private final CSVPrinter out;
 
-  public CsvRecordWriter(OutputStream os, CSVFormat format) throws IOException {
-    out = new CSVPrinter(new OutputStreamWriter(os), format);
+  public CsvRecordWriter(Writer writer, CSVFormat format) throws IOException {
+    out = new CSVPrinter(writer, format);
   }
 
   @Override


### PR DESCRIPTION
This PR adds support for specifying the character set when reading/writing CSV files. The character set is passed to the `CsvInputFormat` and `CsvInputFormat` for constricting a `Reader` or `Writer` with the appropriate character set respectively.