### PR TITLE
Remove /java prefix from JavaDoc output directory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
             <configuration>
               <show>public</show>
               <reportOutputDirectory>docs</reportOutputDirectory>
-              <destDir>java/${project.version}</destDir>
+              <destDir>${project.version}</destDir>
               <links>
                 <link>http://commons.apache.org/csv/apidocs/</link>
                 <link>http://docs.cascading.org/cascading/${cascading.version.major}.${cascading.version.minor}/javadoc/cascading-core/</link>


### PR DESCRIPTION
This PR simply removes the `/java` prefix from the JavaDoc output directory. There's no need! I think it was just left over from one of my other projects.