### PR TITLE
Fix basedir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ branches:
   - master
 after_success:
   - echo "<settings><servers><server><id>conjars.org</id><username>${conjarUser}</username><password>${conjarPassword}</password></server></servers></settings>" > ~/settings.xml
-  - mvn deploy --settings ~/settings.xml
+  - mvn deploy -DskipTests --settings ~/settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>${basedir}/bin/push-javadocs.sh</executable>
+              <executable>${project.basedir}/bin/push-javadocs.sh</executable>
             </configuration>
           </execution>
         </executions>
@@ -217,7 +217,7 @@
           </execution>
         </executions>
         <configuration>
-          <file>${basedir}/README.md</file>
+          <file>${project.basedir}/README.md</file>
           <regex>true</regex>
           <replacements>
             <replacement>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>${project.basedir}/bin/push-javadocs.sh</executable>
+              <executable>${project.basedir}/bin/push-javadoc.sh</executable>
             </configuration>
           </execution>
         </executions>
@@ -251,7 +251,6 @@
       </plugin>
     </plugins>
   </reporting>
-
   <profiles>
     <profile>
       <id>javadoc</id>


### PR DESCRIPTION
This PR changes `basedir` to `project.basedir` and corrects a typo in the execution of a shell script.