### PR TITLE
Ensure iterator is closed after fetching header record

### DIFF
--- a/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
+++ b/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
@@ -659,14 +659,12 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
   private CSVRecord getHeaderRecord(FlowProcess<JobConf> flowProcess, Tap tap) {
     Tap textLine = new Hfs(new TextLine(new Fields("line")), tap.getFullIdentifier(flowProcess.getConfigCopy()));
 
-    try {
-      TupleEntryIterator iterator = textLine.openForRead(flowProcess);
+    try (TupleEntryIterator iterator = textLine.openForRead(flowProcess)) {
       String line = iterator.next().getTuple().getString(0);
       boolean skipHeaderRecord = format.getSkipHeaderRecord();
       CSVRecord headerRecord = CSVParser.parse(line, format.withSkipHeaderRecord(false)).iterator().next();
       format.withSkipHeaderRecord(skipHeaderRecord);
       return headerRecord;
-
     } catch (IOException e) {
       throw new TapException(e);
     }


### PR DESCRIPTION
A resource leak was introduced in b3eb4a9e574c4934536d30bbb58a76c24a055fa5
This PR fixes the leak by ensuring the `TupleEntryIterator` is closed via a try-with-resources statement.