### PR TITLE
Inconsistent rec

### DIFF
--- a/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
+++ b/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
@@ -741,7 +741,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
         try {
           entry.setString(i, value.toString());
         } catch (Exception e) {
-          if (strict) {
+          if (!strict) {
             Tuple tuple = new Tuple();
             for (Text val : values) {
               tuple.addString(val.toString());

--- a/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
+++ b/src/main/java/com/datascience/cascading/scheme/CsvScheme.java
@@ -741,7 +741,7 @@ public class CsvScheme extends Scheme<JobConf, RecordReader, OutputCollector, Ob
         try {
           entry.setString(i, value.toString());
         } catch (Exception e) {
-          if (!strict) {
+          if (strict) {
             Tuple tuple = new Tuple();
             for (Text val : values) {
               tuple.addString(val.toString());

--- a/src/main/java/com/datascience/hadoop/CsvRecordReader.java
+++ b/src/main/java/com/datascience/hadoop/CsvRecordReader.java
@@ -16,6 +16,7 @@
 package com.datascience.hadoop;
 
 import cascading.tap.TapException;
+import cascading.tuple.Tuple;
 import com.datascience.util.CsvParseException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
@@ -73,15 +74,9 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
         CSVRecord record = iterator.next();
         position++;
         colLength = colLength == null ? record.size() : colLength;
-        if (!record.isConsistent() || record.size() != colLength) {
-          try {
-            String message = String.format("%s: %s", "inconsistent record at position", position);
-            if (strict)
-              throw new CsvParseException(message);
-            return next(key, value);
-          } catch(CsvParseException e) {
-            throw new TapException(e);
-          }
+        if ((!record.isConsistent() || record.size() != colLength) && strict) {
+          String message = String.format("%s: %s", "inconsistent record at position", position);
+          throw new CsvParseException(message);
         }
 
         key.set(record.getRecordNumber());
@@ -103,6 +98,7 @@ public class CsvRecordReader implements RecordReader<LongWritable, ListWritable<
         //position = record.getCharacterPosition();
         return true;
       }
+
     } catch (Exception e) {
       LOGGER.warn("failed to parse record at position: " + position);
       if (strict) {

--- a/src/test/java/com/datascience/cascading/CsvSchemeTest.java
+++ b/src/test/java/com/datascience/cascading/CsvSchemeTest.java
@@ -296,7 +296,7 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    CsvScheme sourceScheme= new CsvScheme(sourceFormat);
+    CsvScheme sourceScheme = new CsvScheme(sourceFormat);
     CsvScheme sinkScheme = new CsvScheme(sinkFormat);
 
     testSchemeFields(sourcePath, sourceScheme, sinkPath, sinkScheme, expected);
@@ -326,7 +326,7 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    CsvScheme sourceScheme= new CsvScheme(sourceFormat);
+    CsvScheme sourceScheme = new CsvScheme(sourceFormat);
     CsvScheme sinkScheme = new CsvScheme(sinkFormat);
 
     testSchemeFields(sourcePath, sourceScheme, sinkPath, sinkScheme, expected);
@@ -337,7 +337,7 @@ public class CsvSchemeTest {
    * Test CsvScheme generating Headers when header is defined in source format.
    */
   @Test
-  public void schemeGenerateFieldsWhenSourceFormatHeaderGiven(){
+  public void schemeGenerateFieldsWhenSourceFormatHeaderGiven() {
 
     String sourcePath = "src/test/resources/input/without-headers.txt";
     String sinkPath = "src/test/resources/output/sink-without-headers";
@@ -357,7 +357,7 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    CsvScheme sourceScheme= new CsvScheme(sourceFormat);
+    CsvScheme sourceScheme = new CsvScheme(sourceFormat);
     CsvScheme sinkScheme = new CsvScheme(sinkFormat);
 
     testSchemeFields(sourcePath, sourceScheme, sinkPath, sinkScheme, expected);
@@ -368,7 +368,7 @@ public class CsvSchemeTest {
    * Test CsvScheme Generating headers when Source Fields are provided.
    */
   @Test
-  public void schemeGenerateFieldsWhenSourceFieldsGiven(){
+  public void schemeGenerateFieldsWhenSourceFieldsGiven() {
 
     String sourcePath = "src/test/resources/input/with-headers.txt";
     String sinkPath = "src/test/resources/output/sink-without-headers";
@@ -389,7 +389,7 @@ public class CsvSchemeTest {
 
     Fields sourceFields = new Fields("id", "first name", "last name");
 
-    CsvScheme sourceScheme= new CsvScheme(sourceFields, sourceFormat);
+    CsvScheme sourceScheme = new CsvScheme(sourceFields, sourceFormat);
     CsvScheme sinkScheme = new CsvScheme(sinkFormat);
 
     testSchemeFields(sourcePath, sourceScheme, sinkPath, sinkScheme, expected);
@@ -400,7 +400,7 @@ public class CsvSchemeTest {
    * Test CsvScheme Generating headers when both Source Fields and Headers are provided.
    */
   @Test
-  public void schemeGeneratingHeadersWhenSourceHeadersAndFieldsAreGiven(){
+  public void schemeGeneratingHeadersWhenSourceHeadersAndFieldsAreGiven() {
 
     String sourcePath = "src/test/resources/input/without-headers.txt";
     String sinkPath = "src/test/resources/output/sink-without-headers";
@@ -420,9 +420,9 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    Fields sourceFields = new Fields("id", "first name","last name");
+    Fields sourceFields = new Fields("id", "first name", "last name");
 
-    CsvScheme sourceScheme= new CsvScheme(sourceFields, sourceFormat);
+    CsvScheme sourceScheme = new CsvScheme(sourceFields, sourceFormat);
     CsvScheme sinkScheme = new CsvScheme(sinkFormat);
 
     testSchemeFields(sourcePath, sourceScheme, sinkPath, sinkScheme, expected);
@@ -433,7 +433,7 @@ public class CsvSchemeTest {
    * Tests if correct number of input headers are provided.
    */
   @Test(expected = RuntimeException.class)
-  public void headerCountMismatchColumnsTest(){
+  public void headerCountMismatchColumnsTest() {
 
     String sourcePath = "src/test/resources/input/with-headers.txt";
     String sinkPath = "src/test/resources/output/sink-with-headers";
@@ -451,7 +451,7 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    Tap source = new Hfs(new CsvScheme( sourceFormat), sourcePath);
+    Tap source = new Hfs(new CsvScheme(sourceFormat), sourcePath);
     Tap sink = new Hfs(new CsvScheme(sinkFormat), sinkPath);
     Pipe pipe = new Pipe("pipe");
 
@@ -462,8 +462,8 @@ public class CsvSchemeTest {
   /**
    * Tests if correct number of input fields are provided.
    */
-  @Test(expected=RuntimeException.class)
-  public void fieldsCountGreaterThanColumnsTest(){
+  @Test(expected = RuntimeException.class)
+  public void fieldsCountGreaterThanColumnsTest() {
 
     String sourcePath = "src/test/resources/input/with-headers.txt";
     String sinkPath = "src/test/resources/output/sink-with-headers";
@@ -479,7 +479,7 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    Fields sourceFields = new Fields("id", "last name", "first name","phone");
+    Fields sourceFields = new Fields("id", "last name", "first name", "phone");
     Tap source = new Hfs(new CsvScheme(sourceFields, sourceFormat), sourcePath);
     Tap sink = new Hfs(new CsvScheme(sinkFormat), sinkPath);
     Pipe pipe = new Pipe("pipe");
@@ -500,15 +500,15 @@ public class CsvSchemeTest {
 
     FlowConnector connector = new Hadoop2MR1FlowConnector();
     CSVFormat sourceFormat = CSVFormat.newFormat(',')
-            .withHeader("id","first name", "last name")
-            .withQuote('"')
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withHeader("id", "first name", "last name")
+      .withQuote('"')
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
     CSVFormat sinkFormat = CSVFormat.newFormat('\t')
-            .withSkipHeaderRecord()
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withSkipHeaderRecord()
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
     Fields sourceFields = new Fields("id");
     Tap source = new Hfs(new CsvScheme(sourceFields, sourceFormat), sourcePath);
@@ -522,7 +522,7 @@ public class CsvSchemeTest {
   }
 
   @Test
-  public void testWhenFieldsAndHeadersAreinDifferentOrder() throws Exception{
+  public void testWhenFieldsAndHeadersAreinDifferentOrder() throws Exception {
 
     String sourcePath = "src/test/resources/input/with-headers.txt";
     String sinkPath = "src/test/resources/output/sink-with-headers";
@@ -540,9 +540,9 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    Fields sourceFields = new Fields("id","last name", "first name");
+    Fields sourceFields = new Fields("id", "last name", "first name");
 
-    Tap source = new Hfs(new CsvScheme(sourceFields,sourceFormat), sourcePath);
+    Tap source = new Hfs(new CsvScheme(sourceFields, sourceFormat), sourcePath);
     Tap sink = new Hfs(new CsvScheme(sinkFormat), sinkPath);
 
     Pipe pipe = new Pipe("pipe");
@@ -554,7 +554,7 @@ public class CsvSchemeTest {
   }
 
   @Test
-  public void testWhenExtraColumnsNotStrict() throws Exception{
+  public void testWhenExtraColumnsNotStrict() throws Exception {
     String sourcePath = "src/test/resources/input/with-extra-columns.txt";
     String sinkPath = "src/test/resources/input/sink-with-headers";
     String expectedPath = "src/test/resources/expected/with-extra-columns-no-strict.txt";
@@ -564,8 +564,8 @@ public class CsvSchemeTest {
     FlowConnector connector = new Hadoop2MR1FlowConnector();
     CSVFormat sourceFormat = CSVFormat.newFormat('\t')
       .withQuote('"')
-            .withHeader("id", "first name", "last name", "city", "zip")
-            .withEscape('\\')
+      .withHeader("id", "first name", "last name", "city", "zip")
+      .withEscape('\\')
       .withRecordSeparator('\n');
 
     CSVFormat sinkFormat = CSVFormat.newFormat('\t')
@@ -573,7 +573,7 @@ public class CsvSchemeTest {
       .withEscape('\\')
       .withRecordSeparator('\n');
 
-    Tap source = new Hfs(new CsvScheme(sourceFormat,false), sourcePath);
+    Tap source = new Hfs(new CsvScheme(sourceFormat, false), sourcePath);
     Tap sink = new Hfs(new CsvScheme(sinkFormat), sinkPath, SinkMode.REPLACE);
     Tap trap = new Hfs(new TextDelimited(true, "\t"), trapPath, SinkMode.REPLACE);
 
@@ -585,23 +585,23 @@ public class CsvSchemeTest {
     testPaths(trapPath, expectedTrapPath);
   }
 
-  @Test(expected=FlowException.class)
-  public void testWhenExtraColumnsStrict() throws Exception{
+  @Test(expected = FlowException.class)
+  public void testWhenExtraColumnsStrict() throws Exception {
     String sourcePath = "src/test/resources/input/with-extra-columns.txt";
     String sinkPath = "src/test/resources/input/sink-with-headers";
 
     FlowConnector connector = new Hadoop2MR1FlowConnector();
     CSVFormat sourceFormat = CSVFormat.newFormat('\t')
-            .withHeader("id", "first name", "last name", "city", "zip")
-            .withQuote('"')
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withHeader("id", "first name", "last name", "city", "zip")
+      .withQuote('"')
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
     CSVFormat sinkFormat = CSVFormat.newFormat('\t')
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
-    Tap source = new Hfs(new CsvScheme(sourceFormat,true), sourcePath);
+    Tap source = new Hfs(new CsvScheme(sourceFormat, true), sourcePath);
     Tap sink = new Hfs(new CsvScheme(sinkFormat), sinkPath, SinkMode.REPLACE);
 
     Pipe pipe = new Pipe("pipe");
@@ -610,7 +610,7 @@ public class CsvSchemeTest {
   }
 
   @Test
-  public void testWhenExtraColumnsNotStrictNoHeaders() throws Exception{
+  public void testWhenExtraColumnsNotStrictNoHeaders() throws Exception {
     String sourcePath = "src/test/resources/input/with-extra-columns-no-header.txt";
     String sinkPath = "src/test/resources/input/sink-no-headers";
     String trapPath = "src/test/resources/input/trap-no-headers";
@@ -619,15 +619,15 @@ public class CsvSchemeTest {
 
     FlowConnector connector = new Hadoop2MR1FlowConnector();
     CSVFormat sourceFormat = CSVFormat.newFormat('\t')
-            .withQuote('"')
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withQuote('"')
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
     CSVFormat sinkFormat = CSVFormat.newFormat('\t')
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
-    Tap source = new Hfs(new CsvScheme(sourceFormat,false), sourcePath);
+    Tap source = new Hfs(new CsvScheme(sourceFormat, false), sourcePath);
     Tap sink = new Hfs(new CsvScheme(sinkFormat), sinkPath, SinkMode.REPLACE);
     Tap trap = new Hfs(new TextDelimited(false, "\t"), trapPath, SinkMode.REPLACE);
 
@@ -638,22 +638,22 @@ public class CsvSchemeTest {
     testPaths(trapPath, expectedTrapPath);
   }
 
-  @Test(expected=FlowException.class)
-  public void testWhenExtraColumnsStrictNoHeaders() throws Exception{
+  @Test(expected = FlowException.class)
+  public void testWhenExtraColumnsStrictNoHeaders() throws Exception {
     String sourcePath = "src/test/resources/input/with-extra-columns-no-header.txt";
     String sinkPath = "src/test/resources/input/sink-no-headers";
 
     FlowConnector connector = new Hadoop2MR1FlowConnector();
     CSVFormat sourceFormat = CSVFormat.newFormat('\t')
-            .withQuote('"')
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withQuote('"')
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
     CSVFormat sinkFormat = CSVFormat.newFormat('\t')
-            .withEscape('\\')
-            .withRecordSeparator('\n');
+      .withEscape('\\')
+      .withRecordSeparator('\n');
 
-    Tap source = new Hfs(new CsvScheme(sourceFormat,true), sourcePath);
+    Tap source = new Hfs(new CsvScheme(sourceFormat, true), sourcePath);
     Tap sink = new Hfs(new CsvScheme(sinkFormat), sinkPath, SinkMode.REPLACE);
 
     Pipe pipe = new Pipe("pipe");
@@ -665,7 +665,7 @@ public class CsvSchemeTest {
    * Helper method used for assertion of fields generated by CsvScheme.
    */
   @SuppressWarnings("unchecked")
-  private void testSchemeFields(String sourcePath, CsvScheme sourceSchema, String sinkPath,  CsvScheme sinkScheme, Set<String>expected){
+  private void testSchemeFields(String sourcePath, CsvScheme sourceSchema, String sinkPath, CsvScheme sinkScheme, Set<String> expected) {
 
     Tap source = new Hfs(sourceSchema, sourcePath);
     Tap sink = new Hfs(sinkScheme, sinkPath);
@@ -676,11 +676,11 @@ public class CsvSchemeTest {
 
     Fields sinkFields = sink.getSinkFields();
     for (int i = 0; i < sinkFields.size(); i++) {
-      assertTrue("Unexpected column "+sinkFields.get(i),expected.contains(sinkFields.get(i)));
+      assertTrue("Unexpected column " + sinkFields.get(i), expected.contains(sinkFields.get(i)));
       expected.remove(sinkFields.get(i));
     }
 
-    assertTrue("Not all expected values are found",expected.isEmpty());
+    assertTrue("Not all expected values are found", expected.isEmpty());
 
   }
 

--- a/src/test/java/com/datascience/hadoop/CsvHelper.java
+++ b/src/test/java/com/datascience/hadoop/CsvHelper.java
@@ -32,21 +32,6 @@ import java.net.URL;
  */
 public class CsvHelper {
 
-
-  public Configuration getDefaultConf(){
-    Configuration conf = new Configuration();
-    conf.set("fs.default.name", "file:///");
-    conf.set(CsvInputFormat.CSV_READER_DELIMITER, ",");
-    conf.set(CsvInputFormat.CSV_READER_SKIP_HEADER, "true");
-    conf.set(CsvInputFormat.CSV_READER_RECORD_SEPARATOR, "\n");
-    conf.set(FileSystem.FS_DEFAULT_NAME_KEY, FileSystem.DEFAULT_FS);
-    conf.set("io.compression.codecs", "org.apache.hadoop.io.compress.DefaultCodec,org.apache.hadoop.io.compress.GzipCodec,org.apache.hadoop.io.compress.BZip2Codec,org.apache.hadoop.io.compress.DeflateCodec,org.apache.hadoop.io.compress.SnappyCodec,org.apache.hadoop.io.compress.Lz4Codec");
-    conf.set(CsvInputFormat.CSV_READER_QUOTE_CHARACTER,"\"");
-    conf.setBoolean(CsvInputFormat.STRICT_MODE, false);
-   return conf;
-
-  }
-
   public Configuration buildConfiguration(String delimiter, String skipHeader, String recordSeparator, String[] columns){
      Configuration conf = new Configuration();
     conf.set("fs.default.name", "file:///");
@@ -68,17 +53,13 @@ public class CsvHelper {
     return new File(url.getFile());
   }
 
-
   public RecordReader createRecordReader(InputFormat format, InputSplit split, JobConf jobConf) throws IOException {
     Reporter reporter = Reporter.NULL;
     return format.getRecordReader(split, jobConf, reporter);
   }
 
   public FileSplit createFileSplit(Path path, long start, long end) {
-
     return new FileSplit(path, start, end, new String[0]);
-
   }
-
 
 }

--- a/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvInputFormatTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertTrue;
  * @author amareeshbasanapalli
  */
 public class CsvInputFormatTest {
-
   CsvHelper helper;
   Configuration conf;
   JobConf jobConf;

--- a/src/test/java/com/datascience/hadoop/CsvOutputFormatTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvOutputFormatTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertTrue;
  * @author amareeshbasanapalli
  */
 public class CsvOutputFormatTest  {
-
   Configuration conf;
   CsvHelper helper;
   JobConf jobConf;
@@ -47,7 +46,6 @@ public class CsvOutputFormatTest  {
     helper = new CsvHelper();
     String[] columns = {"id", "first name", "last name"};
    conf= helper.buildConfiguration(",", "true", "\n", columns);
-
   }
 
   /**
@@ -60,7 +58,6 @@ public class CsvOutputFormatTest  {
     conf.set("mapreduce.task.attempt.id", "attempt_200707121733_0003_m_00005_0");
     jobConf = new JobConf(conf);
     fs = FileSystem.get(conf);
-
 
     CsvOutputFormat format = ReflectionUtils.newInstance(CsvOutputFormat.class, conf);
     assertTrue(format.getRecordWriter(fs, jobConf, "output", null) instanceof CsvRecordWriter);
@@ -76,7 +73,6 @@ public class CsvOutputFormatTest  {
     conf.set("mapreduce.task.attempt.id", "attempt_200707121733_0003_m_00005_0");
     jobConf = new JobConf(conf);
     fs = FileSystem.get(conf);
-
 
     CsvOutputFormat format = ReflectionUtils.newInstance(CsvOutputFormat.class, conf);
     assertTrue(format.getRecordWriter(fs, jobConf, "output", null) instanceof CsvRecordWriter);

--- a/src/test/java/com/datascience/hadoop/CsvRecordReaderTest.java
+++ b/src/test/java/com/datascience/hadoop/CsvRecordReaderTest.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * CSV record reader tests.
@@ -70,20 +71,6 @@ public class CsvRecordReaderTest  {
     testForReadAllRecords("/input/with-headers.txt.gz", 3, 6);
   }
 
-  /**
-   * Test to check if records are skipped when strict mode is disabled.
-   */
-  @Test
-  public void readerShouldSkipErrorRecords() throws IOException{
-    conf.set(CsvInputFormat.CSV_READER_QUOTE_CHARACTER,"\"");
-    conf.setBoolean(CsvInputFormat.STRICT_MODE, false);
-    jobConf = new JobConf(conf);
-    fs = FileSystem.get(conf);
-
-    testForReadAllRecords("/input/skipped-lines.txt", 3, 3);
-  }
-
-
   @Test
   public void readingExtraColumnsWhenNotStrict() throws IOException{
 
@@ -93,10 +80,10 @@ public class CsvRecordReaderTest  {
     conf.setBoolean(CsvInputFormat.STRICT_MODE, false);
     jobConf = new JobConf(conf);
     fs = FileSystem.get(conf);
-    testForReadAllRecords("/input/with-extra-columns.txt", 5,5);
+    testForReadAllRecords("/input/with-extra-columns.txt", 7,7);
   }
 
-  @Test(expected= TapException.class)
+  @Test(expected= CsvParseException.class)
   public void readingExtraColumnsWhenStrict() throws IOException{
 
     helper = new CsvHelper();
@@ -146,7 +133,7 @@ public class CsvRecordReaderTest  {
 
       expectedKey++;
 
-      assertEquals(expectedRowLength, value.size());
+      assertTrue((value.size() - expectedRowLength) < 1);
     }
     assertEquals(expectedRecordCount, actualRecordCount);
   }

--- a/src/test/resources/expected/trap-with-extra-columns-no-strict-no-header.txt
+++ b/src/test/resources/expected/trap-with-extra-columns-no-strict-no-header.txt
@@ -1,0 +1,2 @@
+2	Tom	Hummel	LosAngeles	906779	El Segundo	99999
+6	Mark	McKelvy	El Segundo	99999	El Segundo	99999

--- a/src/test/resources/expected/trap-with-extra-columns-no-strict.txt
+++ b/src/test/resources/expected/trap-with-extra-columns-no-strict.txt
@@ -1,0 +1,2 @@
+
+7	Harrison	Cavarallo	LosAngeles	CA	90007	USA

--- a/src/test/resources/expected/with-extra-columns-no-strict-no-header.txt
+++ b/src/test/resources/expected/with-extra-columns-no-strict-no-header.txt
@@ -1,6 +1,5 @@
 col0	col1	col2	col3	col4
 1	Jordan	Halterman	sandiego	90777
-2	Tom	Hummel	LosAngeles	906779
+3	Harrison	Cavarallo		
 4	Badar	Ahmed	Santa Monica	9999
 5	Tristan	Reid	San Fernando	9999
-6	Mark	McKelvy	El Segundo	99999

--- a/src/test/resources/expected/with-extra-columns-no-strict.txt
+++ b/src/test/resources/expected/with-extra-columns-no-strict.txt
@@ -1,6 +1,7 @@
 id	first name	last name	city	zip
 1	Jordan	Halterman	sandiego	90777
 2	Tom	Hummel	LosAngeles	906779
+3	Harrison	Cavarallo		
 4	Badar	Ahmed	Santa Monica	9999
 5	Tristan	Reid	San Fernando	9999
 6	Mark	McKelvy	El Segundo	99999

--- a/src/test/resources/expected/with-extra-columns-strict.txt
+++ b/src/test/resources/expected/with-extra-columns-strict.txt
@@ -1,7 +1,7 @@
 id	first name	last name	city	zip
 1	Jordan	Halterman	sandiego	90777
 2	Tom	Hummel	LosAngeles	906779
-3	Harrison	Cavarallo		
+3	Harrison	Cavarallo
 4	Badar	Ahmed	Santa Monica	9999
 5	Tristan	Reid	San Fernando	9999
 6	Mark	McKelvy	El Segundo	99999

--- a/src/test/resources/input/with-extra-columns-no-header.txt
+++ b/src/test/resources/input/with-extra-columns-no-header.txt
@@ -1,7 +1,6 @@
 1	Jordan	Halterman	sandiego	90777
-2	Tom	Hummel	LosAngeles	906779
+2	Tom	Hummel	LosAngeles	906779	El Segundo	99999
 3	Harrison	Cavarallo
 4	Badar	Ahmed	Santa Monica	9999
 5	Tristan	Reid	San Fernando	9999
-6	Mark	McKelvy	El Segundo	99999
-7	Harrison\tCavarallo\tLosAngeles\tCA 90007
+6	Mark	McKelvy	El Segundo	99999	El Segundo	99999


### PR DESCRIPTION
This PR removes any cascading specific classes from the `CsvRecordReader` and pushes all cascading related error handling to the `CsvScheme`. Because of this, `strict` mode is handled distinctly by each, as well as how to handle inconsistent records (header.size() !== column count). 

`CsvRecordReader` when  `strict == true` will throw a `CsvParseException` upon encountering an inconsistent record. When `strict == false` it will allow the record through and allow the client to handle it. 

`CsvScheme` when `strict == false` will throw a `TapException` which can be logged, trapped, rethrown or allowed to bubble up by the client upon an inconsistent record, but will continue parsing the file. When `strict == true`  the inconsistent record will cause the `CsvScheme` to return false and a `FlowException` will be thrown, ending the parsing of that file. 